### PR TITLE
Git clone causes an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Download the package for your operating system, unpack it and run the `Titan.exe
 #### Option 2: From Source
 
 ```
-$ git clone git@github.com:Marc3842h/Titan.git
+$ git clone https://github.com/Marc3842h/Titan.git
 $ cd Titan
 
 # Run this in a PowerShell terminal on Windows


### PR DESCRIPTION
> git clone git@github.com:Marc3842h/Titan.git
```
Cloning into 'Titan'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

> git clone https://github.com/Marc3842h/Titan.git
```
Cloning into 'Titan'...
remote: Counting objects: 1328, done.
remote: Compressing objects: 100% (128/128), done.
remote: Total 1328 (delta 102), reused 133 (delta 57), pack-reused 1136
Receiving objects: 100% (1328/1328), 644.65 KiB | 0 bytes/s, done.
Resolving deltas: 100% (780/780), done.
Checking connectivity... done.
```

