### PR TITLE
Full fix #3

### DIFF
--- a/Titan/Account/Impl/ProtectedAccount.cs
+++ b/Titan/Account/Impl/ProtectedAccount.cs
@@ -238,7 +238,7 @@ namespace Titan.Account.Impl
                             UIType.TwoFactorAuthentification,
                             new TwoFactorAuthForm(Titan.Instance.UIManager, this, null)));
 
-                        while(_2FactorCode == null)
+                        while(string.IsNullOrEmpty(_2FactorCode))
                         {
                             /* Wait until the Form inputted the 2FA code from the Steam Guard App */
                         }
@@ -253,7 +253,7 @@ namespace Titan.Account.Impl
                     Application.Instance.Invoke(() => Titan.Instance.UIManager.ShowForm(UIType.TwoFactorAuthentification,
                         new TwoFactorAuthForm(Titan.Instance.UIManager, this, callback.EmailDomain)));
 
-                    while(_authCode == null)
+                    while(string.IsNullOrEmpty(_authCode))
                     {
                         /* Wait until the Form inputted the Auth code from the Email Steam sent */
                     }


### PR DESCRIPTION
Now login and create sentry file correctly.

New bug:
http://prntscr.com/g3dosw

in debug console you can see double AuthCode. 
But the server receives the correct _AuthCode

## Description

< Description of your Pull Request >

## Type

```
< Replace with "bugfix", "documentation", "feature" or "breaking change" >
```

## Checklist

*Check the checkbox(es) that apply.*

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [ ] `./build.sh` is passing with every build step and every test locally.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I tested it atleast on **Linux** (and optionally on **Windows**) and its working as intended.

## Discussion

*If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...*

## Reviewers

@Marc3842h, ...
