### PR TITLE
Fix Titan not printing amount of successful commends / reports

### DIFF
--- a/Titan/Account/TitanAccount.cs
+++ b/Titan/Account/TitanAccount.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using SteamKit2;
 using SteamKit2.GC;
@@ -28,7 +28,6 @@ namespace Titan.Account
             JsonAccount = json;
         }
 
-        public bool IsLast = false;
 
         ////////////////////////////////////////////////////
         // TIME

--- a/Titan/Managers/AccountManager.cs
+++ b/Titan/Managers/AccountManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -312,7 +312,6 @@ namespace Titan.Managers
 
             if (Accounts.TryGetValue(index, out var accounts))
             {
-                accounts.Last().IsLast = true;
                 
                 foreach (var acc in accounts)
                 {
@@ -353,7 +352,6 @@ namespace Titan.Managers
 
             if (Accounts.TryGetValue(index, out var accounts))
             {
-                accounts.Last().IsLast = true;
                 
                 foreach (var acc in accounts)
                 {

--- a/Titan/Managers/ThreadManager.cs
+++ b/Titan/Managers/ThreadManager.cs
@@ -93,13 +93,24 @@ namespace Titan.Managers
 
                     if (_taskDic.Count - _count - _failCount == 0)
                     {
-                        _log.Information("SUCCESS! Titan has successfully sent {Amount} out of {Total} reports to {Target}.",
+                        if (_count == 0)
+                        {
+                            _log.Information("FAIL! Titan was not able to report {Target}.",
                             _count, _taskDic.Count, account._reportInfo.SteamID.ConvertToUInt64());
 
-                        Titan.Instance.UIManager.SendNotification(
-                            "Titan", _count + " reports have been successfully sent!"
-                        );
+                            Titan.Instance.UIManager.SendNotification(
+                                "Titan", " was not able to report your target."
+                            );
+                        }
+                        else
+                        {
+                            _log.Information("SUCCESS! Titan has successfully sent {Amount} out of {Total} reports to {Target}.",
+                                _count, _taskDic.Count, account._reportInfo.SteamID.ConvertToUInt64());
 
+                            Titan.Instance.UIManager.SendNotification(
+                                "Titan", _count + " reports have been successfully sent!"
+                            );
+                        }
                         if (Titan.Instance.ParsedObject != null)
                         {
                             Environment.Exit(0);
@@ -189,13 +200,24 @@ namespace Titan.Managers
 
                     if (_taskDic.Count - _count - _failCount == 0)
                     {
-                        _log.Information("SUCCESS! Titan has successfully sent {Amount} out of {Total} commends to {Target}.",
-                            _count,_taskDic.Count, account._reportInfo.SteamID.ConvertToUInt64());
+                        if (_count == 0)
+                        {
+                            _log.Information("FAIL! Titan was not able to commend {Target}.",
+                            _count, _taskDic.Count, account._reportInfo.SteamID.ConvertToUInt64());
 
-                        Titan.Instance.UIManager.SendNotification(
-                            "Titan", _count + " commends have been successfully sent!"
-                        );
+                            Titan.Instance.UIManager.SendNotification(
+                                "Titan", " was not able to commend your target."
+                            );
+                        }
+                        else
+                        {
+                            _log.Information("SUCCESS! Titan has successfully sent {Amount} out of {Total} commends to {Target}.",
+                                _count, _taskDic.Count, account._reportInfo.SteamID.ConvertToUInt64());
 
+                            Titan.Instance.UIManager.SendNotification(
+                                "Titan", _count + " commends have been successfully sent!"
+                            );
+                        }
                         if (Titan.Instance.ParsedObject != null)
                         {
                             Environment.Exit(0);

--- a/Titan/Managers/ThreadManager.cs
+++ b/Titan/Managers/ThreadManager.cs
@@ -100,8 +100,6 @@ namespace Titan.Managers
                             "Titan", _count + " reports have been successfully sent!"
                         );
 
-                        account.IsLast = false;
-
                         if (Titan.Instance.ParsedObject != null)
                         {
                             Environment.Exit(0);
@@ -197,8 +195,6 @@ namespace Titan.Managers
                         Titan.Instance.UIManager.SendNotification(
                             "Titan", _count + " commends have been successfully sent!"
                         );
-
-                        account.IsLast = false;
 
                         if (Titan.Instance.ParsedObject != null)
                         {


### PR DESCRIPTION
## Description

Fix Titan not printing amount of successful commends / reports 

## Type

```
fix
```

## Checklist

*Check the checkbox(es) that apply.*

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] `./build.sh` is passing with every build step and every test locally. 
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I tested it on **Linux** and on **Windows** and it's working as intended. 

## Discussion

*If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...*

## Reviewers

@Marc3842h, Me ofc
