### PR TITLE
Fix accounts.json example commenting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ for_window [class="Titan"] floating enable
 
 Here is the syntax of the accounts.json. You may read more about it on the [wiki](https://github.com/Marc3842h/Titan/wiki/Creating-a-accounts.json).
 
-```json
+```js
 {
     // Per index are maximum 11 accounts allowed. Begin a new index when a new account is required.
     "indexes": [


### PR DESCRIPTION
## Description

JSON standard doesn't support comments, and therefore JSON code blocks in markdown don't. (Indicated by the red highlighting that is seen in the comments). By saying that the block is JavaScript, we can get around this while still having proper syntax highlighting.

## Type

Documentation

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [ ] `./build.sh` is passing with every build step and every test locally.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I tested it on **Linux** and on **Windows** and it's working as intended.

## Discussion

N/A?

## Reviewers

@Marc3842h
